### PR TITLE
ci: wrong trigger branch

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -3,11 +3,11 @@ name: autofix.ci
 on:
   push:
     branches:
-      - master
+      - main
 
   pull_request:
     branches:
-      - master
+      - main
 
   merge_group: {}
 

--- a/.github/workflows/deploy-doc.yml
+++ b/.github/workflows/deploy-doc.yml
@@ -2,7 +2,7 @@ name: GitHub Pages
 on:
   push:
     branches:
-      - master
+      - main
   workflow_dispatch: {}
 
 permissions:

--- a/src/header.ts
+++ b/src/header.ts
@@ -1,13 +1,13 @@
-import type TypeHeader from 'quill/formats/header'
-import Quill from 'quill'
-import { randomID } from './utils'
+import type TypeHeader from 'quill/formats/header';
+import Quill from 'quill';
+import { randomID } from './utils';
 
-const Header = Quill.import('formats/header') as typeof TypeHeader
+const Header = Quill.import('formats/header') as typeof TypeHeader;
 
 export class HeaderWithID extends Header {
   static create(value: any) {
-    const node = super.create(value)
-    node.id = randomID()
-    return node
+    const node = super.create(value);
+    node.id = randomID();
+    return node;
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated workflow configurations to change branch references from `master` to `main` for GitHub Actions workflows.
	- Improved code style consistency in the header component by adding semicolons to import statements and declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->